### PR TITLE
Specified that "Resolve Hierarchy" only works on Annotations

### DIFF
--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -624,7 +624,7 @@ Resolve hierarchy
 -----------------
 *Objects → Annotations... → Resolve hierarchy*  - :kbd:`Ctrl+Shift+R`
 
-Resolve the object hierarchy by setting parent/child relationships between objects based upon regions of interest.
+Resolve the object hierarchy of annotation objects by setting parent/child relationships based upon their relative areas.
 
 Rotate annotation
 -----------------


### PR DESCRIPTION
Hi,

Loving QuPath!  My lab partner and I were trying to better understand the Resolve Hierarchy command and after reading the code in the [resolveHieararchy](https://github.com/qupath/qupath/blob/75ec9cebe5e3bc5843fc60b07b455ce1215e1fb9/qupath-core/src/main/java/qupath/lib/objects/hierarchy/PathObjectHierarchy.java#L269-L292) function we realized that detections aren't included in the process (we have a bunch of cell detections and are trying to insert them into ROI annotations in our slide, which themselves are highly nested).  Just wanted to add the word "annotations" into the docs in case someone else thought the same things we did.

Hope this helps, and keep up the great work!  

Best wishes,

Nick and Estelle