### PR TITLE
Migrate to MyST-Parser

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -28,7 +28,7 @@ author = 'QuPath docs authors'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'recommonmark',
+    'myst_parser',
     'sphinx_rtd_theme',
     'sphinx.ext.autosectionlabel',
     'sphinx_search.extension'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 readthedocs-sphinx-search==0.1.0
+myst-parser==0.15.1
+sphinx-rtd-theme==0.5.2


### PR DESCRIPTION
Hi! 👋🏽 I just had a call with @petebankhead and wanted to follow up with this small PR:

- Migrates to MyST-Parser, since [recommonmark is deprecated](https://github.com/readthedocs/recommonmark/issues/221)
- Updates the version of the Sphinx Read the Docs theme, to solve a small rendering issue that happened with MyST

If you want to see how this pull request looks like before merging it, remember you can enable the https://blog.readthedocs.com/pull-request-builder-general-availability/ :) (and then probably close and reopen it)