### PR TITLE
0.4.3 updates

### DIFF
--- a/docs/advanced/exporting_images.md
+++ b/docs/advanced/exporting_images.md
@@ -63,8 +63,11 @@ Snapshot exports of the *Main window screenshot* (left) and *Main window content
 ::::
 
 :::{tip}
-{doc}`Sending image regions to ImageJ <imagej>` provides another way to save images -- either original pixels or rendered RGB.
-This opens up ImageJ's extra functionality, for example adding a custom scalebar.
+You can customise the scalebar thickness, font size and weight from preferences panel ({menuselection}`Edit --> Preferences --> Viewer`).
+:::
+
+:::{tip}
+{doc}`Sending image regions to ImageJ <imagej>` provides another way to save images -- either original pixels or rendered RGB. This opens up ImageJ's extra functionality, for example further customizing the scalebar.
 :::
 
 ## Export by scripting

--- a/docs/advanced/exporting_images.md
+++ b/docs/advanced/exporting_images.md
@@ -63,7 +63,7 @@ Snapshot exports of the *Main window screenshot* (left) and *Main window content
 ::::
 
 :::{tip}
-You can customise the scalebar thickness, font size and weight from preferences panel ({menuselection}`Edit --> Preferences --> Viewer`).
+You can customize the scalebar thickness, font size and weight from preferences panel ({menuselection}`Edit --> Preferences --> Viewer`).
 :::
 
 :::{tip}

--- a/docs/reference/faqs.md
+++ b/docs/reference/faqs.md
@@ -135,7 +135,7 @@ See {ref}`Installation`.
 
 ### Why can I not set the maximum memory?
 
-QuPath offers a dialog to set the maximum memory on first startup, or through {menuselection}`Help --> Show setup options`.
+You can update the maximum memory QuPath has access to via {menuselection}`Edit --> Preferences --> General --> Set maximum memory for QuPath`.
 This *should* work, but sometimes does not -- possibly due to permissions issues meaning that the necessary config file cannot be overwritten successfully.
 
 To set the memory limit manually, find the `.cfg.` file within your QuPath installation (something like `QuPath-0.2.0.cfg`) and open it in a plain text editor (e.g. Notepad, Atom).

--- a/docs/reference/faqs.md
+++ b/docs/reference/faqs.md
@@ -138,7 +138,7 @@ See {ref}`Installation`.
 You can update the maximum memory QuPath has access to via {menuselection}`Edit --> Preferences --> General --> Set maximum memory for QuPath`.
 This *should* work, but sometimes does not -- possibly due to permissions issues meaning that the necessary config file cannot be overwritten successfully.
 
-To set the memory limit manually, find the `.cfg.` file within your QuPath installation (something like `QuPath-0.2.0.cfg`) and open it in a plain text editor (e.g. Notepad, Atom).
+To set the memory limit manually, find the `.cfg.` file within your QuPath installation (something like `QuPath-0.4.3.cfg`) and open it in a plain text editor (e.g. Notepad, Atom).
 
 The default is to use 50% of available memory, specified under `JavaOptions`:
 

--- a/docs/reference/faqs.md
+++ b/docs/reference/faqs.md
@@ -163,26 +163,6 @@ The config file is inside the *Contents/app* directory.
 
 Yes! See {ref}`Command line`.
 
-### Why does QuPath recommend using US English settings on startup?
-
-For consistency.
-Lots of subtle and thorny issues can happen when representing numbers in different ways, in particular when switching between using dots or commas as the decimal separator.
-
-For example, `1,001` can either be a fairly large number or a small number depending upon where on the world it is read.
-
-In some cases, QuPath has to use the 'dot' representation for decimals (e.g. when scripting), since this is Java's preferred form, and trying to work around this proved too difficult.
-However, forcing everyone to use US English for everything (including exporting results) isn't a perfect solution, especially if other software (e.g. your preferred spreadsheet application) uses something else.
-
-Therefore QuPath does not (currently) insist on its preference for US English... but gives a warning to be **very** cautious about how numbers are represented and interpreted.
-
-There is a more detailed technical description about the issues involved [here](https://github.com/qupath/qupath/issues/29).
-
-:::{figure} ../intro/images/setup_memory.png
-:align: center
-:class: shadow-image
-:width: 60%
-:::
-
 ### Is there a way to make projects self-contained, using the relative paths to images?
 
 QuPath projects currently use a kind of hybrid approach already: storing both the absolute and relative paths to the image files.

--- a/docs/starting/first_steps.md
+++ b/docs/starting/first_steps.md
@@ -124,6 +124,12 @@ The *Magnification box*.
 
 Double-clicking on the magnification value in the toolbar (here, the bit that shows 10.0x) opens an input dialog to enter a specific magnification.
 
+As you zoom in and out, the scalebar in the lower left cover will conveniently update so you always know your scale.
+
+:::{tip}
+You can customise the scalebar thickness, font size and weight from preferences panel ({menuselection}`Edit --> Preferences --> Viewer`).
+:::
+
 ### Panning
 
 To **pan** around a large image within QuPath, first make sure that the **Move** tool {{ icon_move }} is selected in the toolbar.

--- a/docs/starting/first_steps.md
+++ b/docs/starting/first_steps.md
@@ -127,7 +127,7 @@ Double-clicking on the magnification value in the toolbar (here, the bit that sh
 As you zoom in and out, the scalebar in the lower left cover will conveniently update so you always know your scale.
 
 :::{tip}
-You can customise the scalebar thickness, font size and weight from preferences panel ({menuselection}`Edit --> Preferences --> Viewer`).
+You can customize the scalebar thickness, font size and weight from preferences panel ({menuselection}`Edit --> Preferences --> Viewer`).
 :::
 
 ### Panning

--- a/docs/tutorials/multiplex_analysis.md
+++ b/docs/tutorials/multiplex_analysis.md
@@ -11,7 +11,11 @@ This tutorial outlines the basics of how multiplexed images can be analyzed in Q
 We will focus on the main task of identifying each cell, and classifying the cells according to whether they are positive or not for different markers.
 Once this has been done, 'standard' QuPath commands and scripts can be used to interrogate the data.
 
-There are three main steps involved:
+:::{Note}
+If you are looking to quantify stained areas rather than cells or needing to create an annotation **before** running cell detection then {doc}`Measuring areas<../tutorials/measuring_areas>` or {doc}`Pixel classification<../tutorials/pixel_classification>` tutorials may be of interest. Although the examples used in these tutorials are brightfield stains, the methods are the same for fluorescence. When required to enter the "channel" just use the one of interest in your image instead.
+:::
+
+This tutorial has three main steps:
 
 1. Detect & measure cells
 2. Create classifiers for each marker


### PR DESCRIPTION
Amendments to the following:
1. Addition of a section on area quantification for fluorescent images and linking to the other tutorials that are brightfield orientated. 
2. Addition of custom scale bars to the "zooming" section and exporting snapshots (please let me know if I've missed a relevant area or if 2 areas is already too much)
3. Update to the FAQs, removal of mention of the old opening window in the context of both memory management and setting the language. I'm assuming there will be a larger language section come 0.5.0 hence the deletion of one "question" that some of the logic can be transferred into? 

Very much open to discuss alternatives to any of the edits, I was going in circles wondering what was the best approach on my own.