### PR TITLE
Channel viewer tip

### DIFF
--- a/docs/concepts/images.md
+++ b/docs/concepts/images.md
@@ -255,7 +255,7 @@ QuPath supports these images too.
 Furthermore, {menuselection}`View --> Mini viewers --> Show channel viewer` makes it possible to see multiple channels simultaneously, side-by-side.
 
 :::{tip}
-Press and hold {guilabel}`Shift` to pause the viewer or right click on the channel viewer to customize its display.
+Press and hold {guilabel}`Shift` to pause the viewer, or right click on the channel viewer to customize its display.
 :::
 
 :::{figure} images/multichannel_viewer.jpg

--- a/docs/concepts/images.md
+++ b/docs/concepts/images.md
@@ -255,7 +255,7 @@ QuPath supports these images too.
 Furthermore, {menuselection}`View --> Mini viewers --> Show channel viewer` makes it possible to see multiple channels simultaneously, side-by-side.
 
 :::{tip}
-Press and hold {guilabel}`Shift` to pause the viewer, or right click on the channel viewer to customize its display.
+Press and hold {kbd}`Shift` to pause the viewer, or right click on the channel viewer to customize its display.
 :::
 
 :::{figure} images/multichannel_viewer.jpg

--- a/docs/concepts/images.md
+++ b/docs/concepts/images.md
@@ -254,6 +254,10 @@ QuPath supports these images too.
 
 Furthermore, {menuselection}`View --> Mini viewers --> Show channel viewer` makes it possible to see multiple channels simultaneously, side-by-side.
 
+:::{tip}
+Press and hold {guilabel}`Shift` to pause the viewer or right click on the channel viewer to customize its display.
+:::
+
 :::{figure} images/multichannel_viewer.jpg
 :align: center
 :class: shadow-image


### PR DESCRIPTION
The goal is to provide more information on the shortcut and customisation of the channel viewer since there are lots of useful features that may not be initially obvious.

The channel viewer is mentioned in a few places within the docs so I'm not sure if this section should be linked to or the whole tip is copied multiple times? 

In this case the tool is mentioned in the multiplex section but it's also usable in brightfield images. Not sure if it would be worth extracting the main explanation of the tool into it's own section separate of image type for more exposure? 