### PR TITLE
Dependency updates

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -31,8 +31,7 @@ extensions = [
     'myst_parser',
     'sphinx_rtd_theme',
     'sphinx_design',
-    'sphinx.ext.autosectionlabel',
-    'sphinx_search.extension'
+    'sphinx.ext.autosectionlabel'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-readthedocs-sphinx-search==0.3.2
-myst-parser==2.0.0
-sphinx-rtd-theme==1.3.0
-sphinx-design==0.5.0
+myst-parser==4.0.0
+sphinx-rtd-theme==3.0.0
+sphinx-design==0.6.1


### PR DESCRIPTION
This should replace readthedocs-sphinx-search (which is now deprecated) with using the new search add-on. See https://about.readthedocs.com/blog/2024/07/addons-by-default/